### PR TITLE
Add cookie to output_html

### DIFF
--- a/src/Koha/Plugin/VendorAcquisition.pm
+++ b/src/Koha/Plugin/VendorAcquisition.pm
@@ -816,7 +816,7 @@ sub vendor_order_receive {
                     csrf_check => C4::Context->preference("Version") >= 24.05,
                     );
 
-                $self->output_html( $template->output() );
+                $self->output_html( $template->output(), undef, undef, $cookie );
             }
         } else {
             my $template = $self->get_template({file => 'order_failed.tt'});
@@ -860,7 +860,7 @@ sub vendor_order_receive {
             csrf_check => C4::Context->preference("Version") >= 24.05,
             );
 
-        $self->output_html( $template->output() );
+        $self->output_html( $template->output(), undef, undef, $cookie );
 
     } else {
       my ($template, $loggedinuser, $cookie) = C4::Auth::get_template_and_user({
@@ -887,7 +887,7 @@ sub vendor_order_receive {
           request_method => $cgi->request_method
           );
 
-        $self->output_html( $template->output() );
+        $self->output_html( $template->output(), undef, undef, $cookie );
     }
 }
 


### PR DESCRIPTION
This needs bug 40653:
https://bugs.koha-community.org/bugzilla3/show_bug.cgi?id=40653


One of our customers using this plugin has reported it not working for Koha 24.11. We noticed that the authentication was being dropped after arriving to Koha through POST and logging in.
This fixed our issue. 