### PR TITLE
Use "host" instead of "host_port" to compare hosts

### DIFF
--- a/pack.pl
+++ b/pack.pl
@@ -1,0 +1,51 @@
+#!/usr/bin/perl
+
+# Copyright 2026 Magnus Enger, Libriotech <magnus@libriotech.no>
+#
+# This file is part of koha-plugin-disdk-search.
+#
+# koha-plugin-disdk-search is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# koha-plugin-disdk-search is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with koha-plugin-disdk-search; if not, see <http://www.gnu.org/licenses>.
+
+=pod
+
+=head1 pack.pl
+
+Package up the relevant parts as a .kpz Koha plugin file.
+
+=head1 USAGE
+
+  perl pack.pl
+
+=head1 PREREQUISITES
+
+=head2 zip
+
+  sudo apt-get install zip
+
+=cut
+
+use Modern::Perl;
+use lib '.';
+
+my $filename = "/tmp/koha-plugin-vendor-acquisition-imcode-3.1.kpz";
+unlink $filename if -f $filename;
+
+chdir('src') or die "$!";
+say `zip -r $filename Koha/`;
+
+if ( -f $filename ) {
+    say "$filename created";
+} else {
+    say "Oooops, something went wrong!";
+}

--- a/src/Koha/Plugin/VendorAcquisition/Controller.pm
+++ b/src/Koha/Plugin/VendorAcquisition/Controller.pm
@@ -11,9 +11,9 @@ sub add_order {
     my $c = shift->openapi->valid_input or return;
     my $plugin  = Koha::Plugin::VendorAcquisition->new;
     my $in_url = URI->new($c->req->url->to_abs->to_string);
-    my $in_host = $in_url->host_port;
+    my $in_host = $in_url->host;
     my $c_host_uri = URI->new($plugin->retrieve_data('intra_host'));
-    my $c_host = URI->new($plugin->retrieve_data('intra_host'))->host_port;
+    my $c_host = URI->new($plugin->retrieve_data('intra_host'))->host;
 
     if (lc $in_host ne lc $c_host) {
         $c->render(


### PR DESCRIPTION
There is a comparison of hosts that does this before comparing:
      my $in_host = $in_url->host_port;
    
Because of how our servers and proxies are set up this gives us a comparison where the host/domain is the the same, but one gets port 80 and one gets port 443, and the comparison fails. This patch proposes to use "host" instead of "host_port", so the comparison is done on just the host/domain, excluding the port.