### PR TITLE
Use "host" instead of "host_port" to compare hosts

### DIFF
--- a/src/Koha/Plugin/VendorAcquisition/Controller.pm
+++ b/src/Koha/Plugin/VendorAcquisition/Controller.pm
@@ -11,9 +11,9 @@ sub add_order {
     my $c = shift->openapi->valid_input or return;
     my $plugin  = Koha::Plugin::VendorAcquisition->new;
     my $in_url = URI->new($c->req->url->to_abs->to_string);
-    my $in_host = $in_url->host_port;
+    my $in_host = $in_url->host;
     my $c_host_uri = URI->new($plugin->retrieve_data('intra_host'));
-    my $c_host = URI->new($plugin->retrieve_data('intra_host'))->host_port;
+    my $c_host = URI->new($plugin->retrieve_data('intra_host'))->host;
 
     if (lc $in_host ne lc $c_host) {
         $c->render(


### PR DESCRIPTION
There is a comparison of host that does this before comparing:
  my $in_host = $in_url->host_port;

Because of how our servers and proxies are set up this gives us a comparison where the host/domain is the the same, but one gets port 80 and one gets port 443, and the comparison fails. This patch proposes to use "host" instead of "host_port", so the comparison on done on just the host/domain, excluding the port.